### PR TITLE
Fix 'selector' type not working when choices passed as object

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ How it works
 		var1 : {
 			display : 'selector',
 			value : 'a',
-			options : {'a', 'b', 'c'}
+			options : {'choice 1':'value 1', 'choice 2':'value 2', 'choice 3':'value 3'}
 		},
 		var2 : {
 			display : 'range',
@@ -99,7 +99,8 @@ The parameter object can get pretty bloated. Though dat.gui may need all the min
 		var1 : {
 			display : 'selector',
 			value : 'a',
-			options : {'a', 'b', 'c'}
+			options : {'choice 1':'value 1', 'choice 2':'value 2', 'choice 3':'value 3'},
+			onChange : function(value) {}
 		},
 		var2 : {
 			display : 'range',

--- a/guiGlue.js
+++ b/guiGlue.js
@@ -49,21 +49,24 @@ function guiGlue(paramsGUI, optionsGUI){
             //it is critical that none of the tracked parameters is itself an object
             function isLeaf(obj){
 
-                var isLeaf = true;
+                var Leaf = true;
                 for (var key in obj){
-                    if (isLeaf){
+
+                    if (key === 'choices' && obj.display === 'selector') continue;
+
+                    if (Leaf){
                         var isObj = (Object.prototype.toString.call( obj[key] ) != '[object Object]');
-                        isLeaf = isLeaf && isObj;
+                        Leaf = Leaf && isObj;
                     }
                     else
-                        break;
+                        continue;
                 }
 
-                return isLeaf;
+                return Leaf;
 
-            };
+            }
 
-        };
+        }
 
         function addToFolder(key, obj, options, folder, params){
 
@@ -90,7 +93,7 @@ function guiGlue(paramsGUI, optionsGUI){
                 default:
                     handle = folder.add(params, key);
                     break;
-            };
+            }
 
             if (handle && options.onChange)
                 handle.onChange(options.onChange);
@@ -101,10 +104,10 @@ function guiGlue(paramsGUI, optionsGUI){
             if (handle && options.listen)
                 handle.listen();
 
-        };
+        }
 
         return gui;
 
-    };
+    }
 
-};
+}


### PR DESCRIPTION
Fix issue with ‘selector’ type. In script and readme
