### PR TITLE
Add remember() call before adding params into gui

### DIFF
--- a/guiGlue.js
+++ b/guiGlue.js
@@ -74,6 +74,7 @@ function guiGlue(paramsGUI, optionsGUI){
             params[key] = options.value;
 
             var display = options.display || '';
+            gui.remember(params);
 
             switch (display){
                 case 'range':


### PR DESCRIPTION
Enables the saving of gui variables from dat.GUI